### PR TITLE
slash command with verifying request

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,3 +42,8 @@ jobs:
       run: |
         cabal v2-build
         cabal v2-test
+
+    - name: Build example
+      run: |
+        cd example
+        cabal v2-build

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -39,6 +39,7 @@ language_extensions:
 - PolyKinds
 - RankNTypes
 - StandaloneDeriving
+- TupleSections
 - TypeApplications
 - TypeFamilies
 - TypeOperators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 first release
 
 - Feat: Conversations API
+- Feat: User API
+- Feat: Request payload for slash command
+- Feat: Encode verifying signature with request from slack

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,4 @@
 packages:
   ./
   lib/simple-api
-
-source-repository-package
-  type: git
-  location: https://github.com/fumieval/extensible
-  tag: d197daaef0ae18b9734384b8f0efa5783bc629e9
+  lib/extensible-http-api-data

--- a/example/cabal.project
+++ b/example/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  ./
+  ../
+  ../lib/simple-api
+  ../lib/extensible-http-api-data

--- a/example/package.yaml
+++ b/example/package.yaml
@@ -1,0 +1,51 @@
+name:                slackell-example
+version:             0.1.0
+license:             MIT
+author:              MATSUBARA Nobutada
+maintainer:          t12307043@gunma-u.ac.jp
+copyright:           MATSUBARA Nobutada
+category:            Web
+
+ghc-options:
+- -Wall
+- -Wcompat
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
+
+default-extensions:
+- ConstraintKinds
+- DataKinds
+- FlexibleContexts
+- FlexibleInstances
+- GeneralizedNewtypeDeriving
+- LambdaCase
+- OverloadedLabels
+- OverloadedStrings
+- PolyKinds
+- RankNTypes
+- StandaloneDeriving
+- TypeApplications
+- TypeFamilies
+- TypeOperators
+- TypeSynonymInstances
+
+dependencies:
+- aeson
+- base >= 4.7 && < 5
+- bytestring
+- cryptonite
+- extensible >= 0.6.0
+- microlens
+- mtl
+- servant
+- servant-server
+- slackell
+- text
+- unordered-containers
+- warp
+
+executables:
+  app:
+    main: Main.hs
+    source-dirs: src

--- a/example/slackell-example.cabal
+++ b/example/slackell-example.cabal
@@ -1,0 +1,40 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: aaff8c5a19b01e47c901ab4e23f988e3ccdcefbf568ce836dfac8c32883b1cfb
+
+name:           slackell-example
+version:        0.1.0
+category:       Web
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      MATSUBARA Nobutada
+license:        MIT
+build-type:     Simple
+
+executable app
+  main-is: Main.hs
+  other-modules:
+      Paths_slackell_example
+  hs-source-dirs:
+      src
+  default-extensions: ConstraintKinds DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase OverloadedLabels OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , bytestring
+    , cryptonite
+    , extensible >=0.6.0
+    , microlens
+    , mtl
+    , servant
+    , servant-server
+    , slackell
+    , text
+    , unordered-containers
+    , warp
+  default-language: Haskell2010

--- a/example/src/Main.hs
+++ b/example/src/Main.hs
@@ -1,0 +1,53 @@
+module Main where
+
+import           Control.Concurrent       (forkIO)
+import           Control.Monad.Except     (throwError)
+import           Control.Monad.IO.Class   (liftIO)
+import qualified Data.ByteString.Lazy     as LBS
+import           Data.Extensible
+import           Data.String              (fromString)
+import           Data.Text                (Text)
+import qualified Network.Wai.Handler.Warp as Warp
+import           Servant.API
+import           Servant.Server           (Server, err401, serve)
+import           System.Environment       (getEnv)
+import qualified Web.Slack                as Slack
+import           Web.Slack.SlashCommand   (SlashCommand)
+import qualified Web.Slack.SlashCommand   as SlashCmd
+
+main :: IO ()
+main = do
+  secret <- fromString <$> getEnv "SLACK_SIGNING_SECRET"
+  putStrLn "Listening on port 8080"
+  Warp.run 8080 $ serve (Proxy @ API) (server secret)
+
+type API
+    = "slash"
+      :> ReqBody '[SlashCommand] (LBS.ByteString, SlashCmd.RequestData)
+      :> Header "X-Slack-Request-Timestamp" Slack.RequestTimestamp
+      :> Header "X-Slack-Signature" Slack.SignatureHeader
+      :> Post '[JSON] NoContent
+
+server :: Slack.SigningSecret -> Server API
+server secret = slashCommand
+  where
+    slashCommand (lbs, body) (Just ts) (Just sign) =
+      let digest = Slack.encodeSignature secret ts (LBS.toStrict lbs) in
+      if Just digest == Slack.convertSignatureHeader sign then
+        liftIO $ do
+          _ <- forkIO $ action body
+          pure NoContent
+      else
+        throwError err401
+    slashCommand _ _ _ = throwError err401
+
+    action :: SlashCmd.RequestData -> IO ()
+    action body = putStrLn $ "post slash with " <> show (shrink body :: LogData)
+
+type LogData = Record
+  '[ "text"            >: Text
+   , "user_name"       >: Text
+   , "team_domain"       >: Text
+   , "channel_name"    >: Text
+   , "enterprise_name" >: Maybe Text
+   ]

--- a/example/stack.yaml
+++ b/example/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-15.8
+packages:
+- .
+- ..
+- ../lib/simple-api
+- ../lib/extensible-http-api-data
+extra-deps:
+- extensible-0.8
+- membership-0

--- a/lib/extensible-http-api-data/CHANGELOG.md
+++ b/lib/extensible-http-api-data/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog for extensible-http-api-data
+
+## Unreleased changes

--- a/lib/extensible-http-api-data/LICENSE
+++ b/lib/extensible-http-api-data/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 MATSUBARA Nobutada
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/extensible-http-api-data/README.md
+++ b/lib/extensible-http-api-data/README.md
@@ -1,0 +1,3 @@
+# extensible-http-api-data
+
+extensible instances for http-api-data

--- a/lib/extensible-http-api-data/Setup.hs
+++ b/lib/extensible-http-api-data/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/lib/extensible-http-api-data/extensible-http-api-data.cabal
+++ b/lib/extensible-http-api-data/extensible-http-api-data.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 7a6bf34a98715e710cf7d62b4a5760c7886f2825aa7a28350d7f630ebbafb0d7
+
+name:           extensible-http-api-data
+version:        0.1.0
+description:    Please see the README on GitHub at <https://github.com/matsubara0507/extensible-http-api-data#readme>
+category:       Web
+homepage:       https://github.com/matsubara0507/extensible-http-api-data#readme
+author:         MATSUBARA Nobutada
+maintainer:     t12307043@gunma-u.ac.jp
+copyright:      MATSUBARA Nobutada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+  exposed-modules:
+      Data.Extensible.FormUrlEncoded
+  other-modules:
+      Paths_extensible_http_api_data
+  hs-source-dirs:
+      src
+  default-extensions: ConstraintKinds DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  build-depends:
+      base >=4.7 && <5
+    , extensible >=0.6.0
+    , http-api-data
+    , text
+  default-language: Haskell2010

--- a/lib/extensible-http-api-data/package.yaml
+++ b/lib/extensible-http-api-data/package.yaml
@@ -1,12 +1,12 @@
-name:                slackell
+name:                extensible-http-api-data
 version:             0.1.0
-homepage:            https://github.com/matsubara0507/slackell#readme
+homepage:            https://github.com/matsubara0507/extensible-http-api-data#readme
 license:             MIT
 author:              MATSUBARA Nobutada
 maintainer:          t12307043@gunma-u.ac.jp
 copyright:           MATSUBARA Nobutada
 category:            Web
-description:         Please see the README on GitHub at <https://github.com/matsubara0507/slackell#readme>
+description:         Please see the README on GitHub at <https://github.com/matsubara0507/extensible-http-api-data#readme>
 
 extra-source-files:
 - README.md
@@ -25,46 +25,20 @@ default-extensions:
 - FlexibleContexts
 - FlexibleInstances
 - GeneralizedNewtypeDeriving
-- LambdaCase
-- OverloadedLabels
 - OverloadedStrings
 - PolyKinds
 - RankNTypes
 - StandaloneDeriving
-- TupleSections
 - TypeApplications
 - TypeFamilies
 - TypeOperators
 - TypeSynonymInstances
 
 dependencies:
-- aeson
 - base >= 4.7 && < 5
-- base64-bytestring-type
-- bytestring
-- cryptonite
 - extensible >= 0.6.0
-- extensible-http-api-data
 - http-api-data
-- http-media
-- memory
-- microlens
-- req >= 2.0.0
-- servant
-- simple-api
 - text
-- unordered-containers
 
 library:
   source-dirs: src
-
-tests:
-  spec:
-    main:                Spec.hs
-    source-dirs:         test
-    dependencies:
-    - slackell
-    - servant-server
-    - tasty
-    - tasty-hspec
-    - warp

--- a/lib/extensible-http-api-data/src/Data/Extensible/FormUrlEncoded.hs
+++ b/lib/extensible-http-api-data/src/Data/Extensible/FormUrlEncoded.hs
@@ -1,0 +1,35 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Data.Extensible.FormUrlEncoded () where
+
+import           Data.Extensible
+import           Data.Functor.Identity (Identity)
+import           Data.Int              (Int64)
+import           Data.Text             (Text)
+import           Web.FormUrlEncoded
+import           Web.HttpApiData
+
+instance Forall (KeyTargetAre KnownSymbol FromFormData) xs => FromForm (Record xs) where
+  fromForm form =
+    hgenerateFor (Proxy @ (KeyTargetAre KnownSymbol FromFormData)) $ \m ->
+      Field <$> parseUnique' (stringKeyOf m) form
+
+class FromFormData a where
+  parseUnique' :: Text -> Form -> Either Text a
+
+instance FromFormData Int where parseUnique' = parseUnique
+instance FromFormData Float where parseUnique' = parseUnique
+instance FromFormData Bool where parseUnique' = parseUnique
+instance FromFormData Char where parseUnique' = parseUnique
+instance FromFormData Int64 where parseUnique' = parseUnique
+instance FromFormData Text where parseUnique' = parseUnique
+
+instance FromHttpApiData a => FromFormData (Maybe a) where
+  parseUnique' key form = do
+    mv <- lookupMaybe key form
+    case mv of
+      Just v  -> Just <$> parseQueryParam v
+      Nothing -> pure Nothing
+
+instance FromFormData a => FromFormData (Identity a) where
+  parseUnique' key form = pure <$> parseUnique' key form

--- a/package.yaml
+++ b/package.yaml
@@ -50,7 +50,7 @@ dependencies:
 - memory
 - microlens
 - req >= 2.0.0
-- servant
+- servant >= 0.4.0
 - simple-api
 - text
 - unordered-containers

--- a/package.yaml
+++ b/package.yaml
@@ -40,12 +40,14 @@ dependencies:
 - aeson
 - base >= 4.7 && < 5
 - bytestring
+- cryptonite
 - extensible >= 0.6.0
+- memory
+- microlens
 - req >= 2.0.0
 - simple-api
 - text
 - unordered-containers
-- microlens
 
 library:
   source-dirs: src

--- a/slackell.cabal
+++ b/slackell.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 70912dc5926afe30e82ea496c9f1726def763b2c9bdecc8deb616317b6a3dfda
+-- hash: 2434b3a05886a7119d15ef832b580805a29ba5bc5c762de605f64da25a59ebd3
 
 name:           slackell
 version:        0.1.0
@@ -25,6 +25,7 @@ library
   exposed-modules:
       Web.Slack
       Web.Slack.Client
+      Web.Slack.SlashCommand
       Web.Slack.Type
       Web.Slack.Verify
       Web.Slack.WebAPI
@@ -35,17 +36,22 @@ library
       Paths_slackell
   hs-source-dirs:
       src
-  default-extensions: ConstraintKinds DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase OverloadedLabels OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  default-extensions: ConstraintKinds DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase OverloadedLabels OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson
     , base >=4.7 && <5
+    , base64-bytestring-type
     , bytestring
     , cryptonite
     , extensible >=0.6.0
+    , extensible-http-api-data
+    , http-api-data
+    , http-media
     , memory
     , microlens
     , req >=2.0.0
+    , servant
     , simple-api
     , text
     , unordered-containers
@@ -65,17 +71,22 @@ test-suite spec
       Paths_slackell
   hs-source-dirs:
       test
-  default-extensions: ConstraintKinds DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase OverloadedLabels OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  default-extensions: ConstraintKinds DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase OverloadedLabels OverloadedStrings PolyKinds RankNTypes StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson
     , base >=4.7 && <5
+    , base64-bytestring-type
     , bytestring
     , cryptonite
     , extensible >=0.6.0
+    , extensible-http-api-data
+    , http-api-data
+    , http-media
     , memory
     , microlens
     , req >=2.0.0
+    , servant
     , servant-server
     , simple-api
     , slackell

--- a/slackell.cabal
+++ b/slackell.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2434b3a05886a7119d15ef832b580805a29ba5bc5c762de605f64da25a59ebd3
+-- hash: 9dcc686f0f4ec59d0128b16b6d8edb50ec97acab689dddaf25f0592425a60de9
 
 name:           slackell
 version:        0.1.0
@@ -51,7 +51,7 @@ library
     , memory
     , microlens
     , req >=2.0.0
-    , servant
+    , servant >=0.4.0
     , simple-api
     , text
     , unordered-containers
@@ -86,7 +86,7 @@ test-suite spec
     , memory
     , microlens
     , req >=2.0.0
-    , servant
+    , servant >=0.4.0
     , servant-server
     , simple-api
     , slackell

--- a/slackell.cabal
+++ b/slackell.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5e8b1313d9aadaeb3a2d047d4c57afaa4620a86e92a707543d397ae4a4eee12c
+-- hash: 70912dc5926afe30e82ea496c9f1726def763b2c9bdecc8deb616317b6a3dfda
 
 name:           slackell
 version:        0.1.0
@@ -26,6 +26,7 @@ library
       Web.Slack
       Web.Slack.Client
       Web.Slack.Type
+      Web.Slack.Verify
       Web.Slack.WebAPI
       Web.Slack.WebAPI.Conversations
       Web.Slack.WebAPI.Internal
@@ -40,7 +41,9 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
+    , cryptonite
     , extensible >=0.6.0
+    , memory
     , microlens
     , req >=2.0.0
     , simple-api
@@ -52,6 +55,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Spec.Web.Slack.Verify
       Spec.Web.Slack.WebAPI.Conversations
       Spec.Web.Slack.WebAPI.Users
       Web.Slack.Test.Client
@@ -67,7 +71,9 @@ test-suite spec
       aeson
     , base >=4.7 && <5
     , bytestring
+    , cryptonite
     , extensible >=0.6.0
+    , memory
     , microlens
     , req >=2.0.0
     , servant-server

--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -4,4 +4,5 @@ module Web.Slack
 
 import           Web.Slack.Client as X
 import           Web.Slack.Type   as X
+import           Web.Slack.Verify as X
 import           Web.Slack.WebAPI as X

--- a/src/Web/Slack/SlashCommand.hs
+++ b/src/Web/Slack/SlashCommand.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Web.Slack.SlashCommand
+    ( SlashCommand
+    , RequestData
+    ) where
+
+import           Control.Arrow                  ((+++))
+import           Data.ByteString.Lazy           (ByteString)
+import           Data.Extensible
+import           Data.Extensible.FormUrlEncoded ()
+import           Data.Text                      (Text)
+import qualified Data.Text                      as Text
+import qualified Network.HTTP.Media             as M
+import           Servant.API.ContentTypes
+import           Web.FormUrlEncoded             (urlDecodeAsForm)
+
+type RequestData = Record
+  '[ "token"           >: Text
+   , "command"         >: Text
+   , "text"            >: Text
+   , "response_url"    >: Text
+   , "trigger_id"      >: Text
+   , "user_id"         >: Text
+   , "user_name"       >: Text
+   , "team_id"         >: Text
+   , "team_domain"     >: Text
+   , "channel_id"      >: Text
+   , "channel_name"    >: Text
+   , "enterprise_id"   >: Maybe Text
+   , "enterprise_name" >: Maybe Text
+   ]
+
+data SlashCommand
+
+instance Accept SlashCommand where
+  contentType _ = "application" M.// "x-www-form-urlencoded"
+
+instance MimeUnrender SlashCommand (ByteString, RequestData) where
+  mimeUnrender _ bs = Text.unpack +++ (bs,) $ urlDecodeAsForm bs

--- a/src/Web/Slack/Verify.hs
+++ b/src/Web/Slack/Verify.hs
@@ -1,0 +1,26 @@
+module Web.Slack.Verify
+    ( SigningSecret
+    , encodeSignature
+    , convertToDigest
+    ) where
+
+import           Crypto.Hash             (Digest, SHA256, digestFromByteString)
+import           Crypto.MAC.HMAC         (HMAC (..), hmac)
+import           Data.ByteArray.Encoding (Base (..), convertFromBase)
+import           Data.ByteString         (ByteString)
+import qualified Data.ByteString         as BS
+import           Data.String             (IsString)
+import           Data.Text               (Text)
+import qualified Data.Text.Encoding      as Text
+
+newtype SigningSecret = SigningSecret Text deriving (IsString)
+
+type RequestTimestamp = ByteString
+
+encodeSignature :: SigningSecret -> RequestTimestamp -> ByteString -> Digest SHA256
+encodeSignature (SigningSecret secret) ts body =
+  hmacGetDigest $ hmac (Text.encodeUtf8 secret) (BS.intercalate ":" ["v0", ts, body])
+
+convertToDigest :: ByteString -> Maybe (Digest SHA256)
+convertToDigest bs =
+  either (const Nothing) digestFromByteString (convertFromBase Base16 bs :: Either String ByteString)

--- a/src/Web/Slack/Verify.hs
+++ b/src/Web/Slack/Verify.hs
@@ -1,3 +1,5 @@
+-- | ref: https://api.slack.com/authentication/verifying-requests-from-slack
+
 module Web.Slack.Verify
     ( SigningSecret
     , RequestTimestamp

--- a/src/Web/Slack/Verify.hs
+++ b/src/Web/Slack/Verify.hs
@@ -1,7 +1,9 @@
 module Web.Slack.Verify
     ( SigningSecret
+    , RequestTimestamp
+    , SignatureHeader
     , encodeSignature
-    , convertToDigest
+    , convertSignatureHeader
     ) where
 
 import           Crypto.Hash             (Digest, SHA256, digestFromByteString)
@@ -11,16 +13,26 @@ import           Data.ByteString         (ByteString)
 import qualified Data.ByteString         as BS
 import           Data.String             (IsString)
 import           Data.Text               (Text)
+import qualified Data.Text               as Text
 import qualified Data.Text.Encoding      as Text
 
 newtype SigningSecret = SigningSecret Text deriving (IsString)
 
-type RequestTimestamp = ByteString
+type RequestTimestamp = Text
+
+type SignatureHeader = Text
 
 encodeSignature :: SigningSecret -> RequestTimestamp -> ByteString -> Digest SHA256
 encodeSignature (SigningSecret secret) ts body =
-  hmacGetDigest $ hmac (Text.encodeUtf8 secret) (BS.intercalate ":" ["v0", ts, body])
+  hmacGetDigest $ hmac (Text.encodeUtf8 secret) basestr
+  where
+    basestr = BS.intercalate ":" [Text.encodeUtf8 version, Text.encodeUtf8 ts, body]
 
-convertToDigest :: ByteString -> Maybe (Digest SHA256)
-convertToDigest bs =
-  either (const Nothing) digestFromByteString (convertFromBase Base16 bs :: Either String ByteString)
+convertSignatureHeader :: SignatureHeader -> Maybe (Digest SHA256)
+convertSignatureHeader sign = either (const Nothing) digestFromByteString bs
+  where
+    (_, sign') = Text.breakOnEnd (version <> "=") sign
+    bs = convertFromBase Base16 (Text.encodeUtf8 sign') :: Either String ByteString
+
+version :: Text
+version = "v0"

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-15.8
 packages:
 - .
 - lib/simple-api
+- lib/extensible-http-api-data
 extra-deps:
 - extensible-0.8
 - membership-0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,7 @@
-resolver: lts-14.22
+resolver: lts-15.8
 packages:
 - .
 - lib/simple-api
 extra-deps:
+- extensible-0.8
 - membership-0
-- req-3.0.0
-- github: fumieval/extensible
-  commit: d197daaef0ae18b9734384b8f0efa5783bc629e9

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,3 +1,4 @@
+import qualified Spec.Web.Slack.Verify
 import qualified Spec.Web.Slack.WebAPI.Conversations
 import qualified Spec.Web.Slack.WebAPI.Users
 import           Test.Tasty
@@ -11,6 +12,7 @@ spec :: IO TestTree
 spec = testGroup "Web.Slack" <$> sequence
   [ Spec.Web.Slack.WebAPI.Conversations.specWith client
   , Spec.Web.Slack.WebAPI.Users.specWith client
+  , Spec.Web.Slack.Verify.spec
   ]
   where
     client = TestClient

--- a/test/Spec/Web/Slack/Verify.hs
+++ b/test/Spec/Web/Slack/Verify.hs
@@ -1,0 +1,18 @@
+module Spec.Web.Slack.Verify
+    ( spec
+    ) where
+
+
+import           Test.Tasty
+import           Test.Tasty.Hspec
+import           Web.Slack.Verify
+
+spec :: IO TestTree
+spec = testSpec "Web.Slack.Verify" $
+  describe "encodeSignature" $ do
+    let secret = "8f742231b10e8888abcd99yyyzzz85a5"
+        body = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
+        timestamp = "1531420618"
+        expect = "a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"
+    it "should return hex digest" $
+      Just (encodeSignature secret timestamp body) `shouldBe` convertToDigest expect

--- a/test/Spec/Web/Slack/Verify.hs
+++ b/test/Spec/Web/Slack/Verify.hs
@@ -10,6 +10,8 @@ import           Web.Slack.Verify
 spec :: IO TestTree
 spec = testSpec "Web.Slack.Verify" $
   describe "encodeSignature" $ do
+    -- | following secret etc.. is in official docs
+    -- | ref: https://api.slack.com/authentication/verifying-requests-from-slack
     let secret = "8f742231b10e8888abcd99yyyzzz85a5"
         body = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
         timestamp = "1531420618"

--- a/test/Spec/Web/Slack/Verify.hs
+++ b/test/Spec/Web/Slack/Verify.hs
@@ -13,6 +13,6 @@ spec = testSpec "Web.Slack.Verify" $
     let secret = "8f742231b10e8888abcd99yyyzzz85a5"
         body = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
         timestamp = "1531420618"
-        expect = "a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"
+        expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"
     it "should return hex digest" $
-      Just (encodeSignature secret timestamp body) `shouldBe` convertToDigest expect
+      Just (encodeSignature secret timestamp body) `shouldBe` convertSignatureHeader expect


### PR DESCRIPTION
- add encode [verifying signature](https://api.slack.com/authentication/verifying-requests-from-slack) function with request from slack
- add data type for slash command
- add extensible-http-api-data package: `FromForm` instance for extensible record type



and more:

- update lts to 15.8
- add example for this feature